### PR TITLE
Execute GitHub Actions for every pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,10 @@
 name: .NET Core
 
-on:
-  push:
-    branches:
-      - dev
-      - master
-  pull_request:
-    branches:
-      - dev
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     env:
       TESTS_PROJECT: 'SharpFileSystem.Tests/SharpFileSystem.Tests.csproj' # path to test project or solution
-      PUBLISH_NUGET: true # if true a nuget will be published on version change
       RUN_TESTS: true # if true tests are run and coverage data is published to coveralls and a coverage report is produced.
       MAIN_CSPROJ: 'SharpCoreFileSystem/SharpCoreFileSystem.csproj' # main project (for nuget packaging)
     runs-on: ${{ matrix.os }}
@@ -21,13 +12,13 @@ jobs:
         matrix:
           os: [ubuntu-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 3.1.101
     - name: Clean artifacts and nugets
-      run: dotnet clean  --configuration Release && dotnet nuget locals all --clear
+      run: dotnet clean --configuration Release && dotnet nuget locals all --clear
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet
@@ -55,7 +46,7 @@ jobs:
         verbosity: 'Info' # The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off
         tag: '${{ github.run_number }}_${{ github.run_id }}'
     - name: publish nuget
-      if: matrix.os == 'windows-latest' && env.PUBLISH_NUGET
+      if: matrix.os == 'windows-latest' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       id: publish_nuget
       uses: brandedoutcast/publish-nuget@v2.5.5
       with:
@@ -86,6 +77,7 @@ jobs:
         asset_name: ${{ steps.publish_nuget.outputs.PACKAGE_NAME }}
         asset_content_type: application/zip
     - name: Invoke refresh readme badges
+      if: contains(github.ref, 'master')
       uses: benc-uk/workflow-dispatch@v1
       with:
         workflow: refresh readme badges


### PR DESCRIPTION
The GitHub Actions weren't triggered for pull requests. The NuGet publishing only happens now if there's a new git tag.